### PR TITLE
fix: 'top' property set on new cells

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,8 @@ const createNextLine = (line) => {
     if (cell.bottom) {
       newCell._set = 0;
     }
-
+    
+    newCell.top = cell.bottom;
     newCell.right = false;
     newCell.left = false;
     newCell.bottom = false;


### PR DESCRIPTION
This PR aims to solve the problem detected at the [Issue #1](https://github.com/ihorbeliasnyk/ellerjs/issues/1).

The solution provided is to set the `top` property to `true` when the cell directly above the current cell has the `bottom` property set to `true`.

All the tests passed.